### PR TITLE
fix: debounce chat labels updates

### DIFF
--- a/src/components/builder/editors/appearance/views/Form/components/ChatLabelsSection/ChatLabelsSubSection.tsx
+++ b/src/components/builder/editors/appearance/views/Form/components/ChatLabelsSection/ChatLabelsSubSection.tsx
@@ -2,7 +2,7 @@ import debounce from 'lodash-es/debounce';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { INPUT_DEBOUNCE } from '@/constants/app';
-import { type ChatLabelKey,DEFAULT_CHAT_LABELS } from '@/constants/chat/chatLabels';
+import { type ChatLabelKey, DEFAULT_CHAT_LABELS } from '@/constants/chat/chatLabels';
 import { AppearanceActions, AppearanceSelectors } from '@/store/builder/appearance/appearance.reducers';
 import { useBuilderDispatch, useBuilderSelector } from '@/store/builder/hooks';
 import { UISelectors } from '@/store/builder/ui/ui.reducers';
@@ -30,8 +30,8 @@ export const ChatLabelsSubSection = ({ section }: { section: ChatLabelFormSectio
   const theme = useBuilderSelector(UISelectors.selectTheme) || 'dark';
   const config = useBuilderSelector(AppearanceSelectors.selectThemeConfig);
 
-  const [localValues, setLocalValues] = useState<Record<string, string>>(
-    () => Object.fromEntries(section.fields.map(({ key }) => [key, config?.chat?.labels?.[key] ?? ''])),
+  const [localValues, setLocalValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(section.fields.map(({ key }) => [key, config?.chat?.labels?.[key] ?? ''])),
   );
 
   useEffect(() => {

--- a/src/components/builder/editors/appearance/views/Form/components/ChatLabelsSection/ChatLabelsSubSection.tsx
+++ b/src/components/builder/editors/appearance/views/Form/components/ChatLabelsSection/ChatLabelsSubSection.tsx
@@ -1,5 +1,7 @@
-import { useCallback } from 'react';
+import debounce from 'lodash-es/debounce';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { INPUT_DEBOUNCE } from '@/constants/app';
 import { type ChatLabelKey,DEFAULT_CHAT_LABELS } from '@/constants/chat/chatLabels';
 import { AppearanceActions, AppearanceSelectors } from '@/store/builder/appearance/appearance.reducers';
 import { useBuilderDispatch, useBuilderSelector } from '@/store/builder/hooks';
@@ -21,10 +23,20 @@ const pruneLabels = (raw: Record<string, string | undefined>): ChatLabels | unde
   return Object.fromEntries(entries.map(([k, v]) => [k, (v as string).trim()])) as ChatLabels;
 };
 
+const EDITOR_DEBOUNCE = INPUT_DEBOUNCE * 2;
+
 export const ChatLabelsSubSection = ({ section }: { section: ChatLabelFormSection }) => {
   const dispatch = useBuilderDispatch();
   const theme = useBuilderSelector(UISelectors.selectTheme) || 'dark';
   const config = useBuilderSelector(AppearanceSelectors.selectThemeConfig);
+
+  const [localValues, setLocalValues] = useState<Record<string, string>>(
+    () => Object.fromEntries(section.fields.map(({ key }) => [key, config?.chat?.labels?.[key] ?? ''])),
+  );
+
+  useEffect(() => {
+    setLocalValues(Object.fromEntries(section.fields.map(({ key }) => [key, config?.chat?.labels?.[key] ?? ''])));
+  }, [config?.chat?.labels, section.fields]);
 
   const persistKey = useCallback(
     (key: ChatLabelKey, raw: string) => {
@@ -61,6 +73,8 @@ export const ChatLabelsSubSection = ({ section }: { section: ChatLabelFormSectio
     [config, dispatch, theme],
   );
 
+  const debouncedPersist = useMemo(() => debounce(persistKey, EDITOR_DEBOUNCE), [persistKey]);
+
   return (
     <div className="flex flex-col gap-5">
       {section.fields.map(({ key, label }) => (
@@ -70,9 +84,16 @@ export const ChatLabelsSubSection = ({ section }: { section: ChatLabelFormSectio
           </label>
           <input
             id={`chat-label-${section.id}-${key}`}
-            value={config?.chat?.labels?.[key] ?? ''}
+            value={localValues[key] ?? ''}
             placeholder={DEFAULT_CHAT_LABELS[key]}
-            onChange={e => persistKey(key, e.target.value)}
+            onChange={e => {
+              const val = e.target.value;
+              setLocalValues(prev => ({ ...prev, [key]: val }));
+              debouncedPersist(key, val);
+            }}
+            onBlur={() => {
+              debouncedPersist.flush();
+            }}
             className={inputClassName}
           />
         </div>

--- a/src/components/builder/editors/appearance/views/Form/components/FontsSection/GoogleFontInput.tsx
+++ b/src/components/builder/editors/appearance/views/Form/components/FontsSection/GoogleFontInput.tsx
@@ -1,6 +1,7 @@
-import { INPUT_DEBOUNCE } from '@/constants/app';
 import debounce from 'lodash-es/debounce';
 import { useMemo } from 'react';
+
+import { INPUT_DEBOUNCE } from '@/constants/app';
 
 interface Props {
   fontFamily?: string;

--- a/src/components/builder/editors/appearance/views/Form/components/FontsSection/GoogleFontInput.tsx
+++ b/src/components/builder/editors/appearance/views/Form/components/FontsSection/GoogleFontInput.tsx
@@ -1,7 +1,6 @@
+import { INPUT_DEBOUNCE } from '@/constants/app';
 import debounce from 'lodash-es/debounce';
 import { useMemo } from 'react';
-
-const INPUT_DEBOUNCE = 500;
 
 interface Props {
   fontFamily?: string;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #45 

### Description of changes

Previously, every keystroke in the chat labels editor dispatched a Redux action that triggered a network call. This adds local state for immediate UI feedback and debounces the actual persistence to 1000ms, so the network is only hit after the user pauses typing. An onBlur flush ensures no changes are lost when the user leaves a field before the debounce fires.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.